### PR TITLE
run ether-wake using sudo

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -345,7 +345,7 @@ function wol_node {
 
     update_credentials
     echo "Sending wol packet to node with mac:" $1
-    ether-wake -b -i ${ADMIN_NETWORK_interface} $1
+    sudo /sbin/ether-wake -b -i ${ADMIN_NETWORK_interface} $1
 
 }
 


### PR DESCRIPTION
if non-root user executes the script (eg zabbix) the host powered down host will never receive wol since ether-wake requires root privileges
