### PR TITLE
remove sudo from etherwake

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -345,8 +345,9 @@ function wol_node {
 
     update_credentials
     echo "Sending wol packet to node with mac:" $1
-    sudo /sbin/ether-wake -b -i ${ADMIN_NETWORK_interface} $1
-
+    for i in {1..10}; do
+      /sbin/ether-wake -b -i ${ADMIN_NETWORK_interface} ${1};
+    done
 }
 
 function check_nodes_count {


### PR DESCRIPTION
sudo doesn't really work when the script is initiated by zabbix agent, we are setting suid instead
